### PR TITLE
GAIFAGP-292 - Update SpatiaLite with Catalog IDs with additional support

### DIFF
--- a/dba/update/add_ids_from_file.py
+++ b/dba/update/add_ids_from_file.py
@@ -1,0 +1,47 @@
+# ------------------------------------------------------------------------------
+#
+# Adds US Goverment Catalog IDs and Entity IDs when provide with Vendor IDs as
+#      file names of GeoTIFFs.
+#
+# Written by John Wall (john.wall@noaa.gov)
+#
+# ------------------------------------------------------------------------------
+
+# Import some libraries, configure Django
+import os
+import django
+import zipfile
+import pandas as pd
+import geopandas as gd
+from glob import glob
+from time import time
+import geopandas as gpd
+import subprocess
+from shapely.wkt import loads
+import xml.etree.ElementTree as ET
+
+import sys; sys.path.append('../../')
+os.environ['DJANGO_SETTINGS_MODULE'] = 'gaia.settings'
+django.setup()
+
+from asgiref.sync import sync_to_async
+from django.core.management import call_command
+from django.contrib.gis.geos import GEOSGeometry
+
+from animal.models import PointsOfInterest as POI
+
+# User define variables
+data_dir = "../../../gis/data/"
+local_geojson = "files.geojson"
+
+# Read GeoJSON into memory
+data_dir = os.path.abspath(data_dir)
+filepath = os.path.join(data_dir, local_geojson)
+gdf = gd.read_file(filepath)
+
+# Keep only relevant columns, update Vendor ID for database
+gdf = gdf[['Entity ID', 'Vendor ID', 'Catalog ID']]
+gdf['Vendor ID'] = gdf['Vendor ID'].str.replace(r'P1BS|M1BS', 'S1BS', regex=True)
+gdf = gdf.drop_duplicates(subset='Vendor ID', keep='first')
+
+# No further work done on this as the data appears to be incomplete...

--- a/dba/update/add_ids_from_files.py
+++ b/dba/update/add_ids_from_files.py
@@ -1,0 +1,124 @@
+# ------------------------------------------------------------------------------
+#
+# Adds US Goverment Catalog IDs IDs when provide with Vendor IDs as file names
+#      of GeoTIFFs.
+#
+# Written by John Wall (john.wall@noaa.gov)
+#
+# ------------------------------------------------------------------------------
+
+# ----------------------------
+# Import some libraries, configure Django
+# ----------------------------
+import os
+import django
+import zipfile
+import pandas as pd
+from glob import glob
+from time import time
+import geopandas as gpd
+import subprocess
+from shapely.wkt import loads
+import xml.etree.ElementTree as ET
+
+import sys; sys.path.append('../../')
+os.environ['DJANGO_SETTINGS_MODULE'] = 'gaia.settings'
+django.setup()
+
+from asgiref.sync import sync_to_async
+from django.core.management import call_command
+from django.contrib.gis.geos import GEOSGeometry
+
+from animal.models import PointsOfInterest as POI
+
+# ----------------------------
+# User defined variables
+# ----------------------------
+data_dir = "../../../gis/data/"
+sub_dir = "imagery/azure/original/"
+geojson_dir = "geojson"
+
+# ----------------------------
+# Locally defined functions
+# ----------------------------
+def update_poi_from_dataframe(df, dry_run=True):
+    ''' Update the Point of Interest table values for Catalog ID and Vendor ID
+            based on Vendor ID when provided with a Pandas Dataframe. Allows
+            for a dry run prior to executing to ensure values make sense.
+
+        DF - A Pandas Dataframe with Catalog, Entity, and Vendor IDs
+        DRY RUN - A boolean (T/F) for testing.
+    '''
+    for _, row in df.iterrows():
+        vendor_id = row['vendor_id']
+        catalog_id = row['catalog_id']
+
+        qs = POI.objects.filter(vendor_id=vendor_id)
+
+        if dry_run:
+            count = qs.count()
+            print(f"[DRY RUN] Would update {count} rows for vendor_id '{vendor_id}' "
+                  f"=> catalog_id='{catalog_id}'")
+        else:
+            updated = qs.update(
+                catalog_id=catalog_id,
+            )
+            print(f"Updated {updated} rows for vendor_id '{vendor_id}'")
+
+def get_catid_from_xml(xml_path):
+    ''' When provided with an XML file, searches for the CATID tag returning its
+            value.
+        
+        XML PATH - Path to a local XML file.
+    '''
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+
+    catid_element = root.find(".//CATID")
+    if catid_element is not None:
+        return catid_element.text.strip()
+    else:
+        return None
+
+# ----------------------------
+# Prepare a Pandas dataframe
+# ----------------------------
+pdf = pd.DataFrame(columns=['catalog_id', 'vendor_id'])
+
+# ----------------------------
+# Retrieve all GeoTIFF files, build the Pandas dataframe
+# ----------------------------
+data_dir = os.path.abspath(data_dir)
+geotiffs = glob(os.path.join(data_dir, sub_dir, '**', "*.tif"), recursive=True)
+
+for geotiff in geotiffs:
+    vendor_id = geotiff.split('\\')[-1].split('.')[0]
+
+    # Note this is redundant since we're doing it for pan and multispectral
+    if 'P1BS' in vendor_id:
+        vendor_id = vendor_id.replace('P1BS', 'S1BS')
+    elif 'M1BS' in vendor_id:
+        vendor_id = vendor_id.replace('M1BS', 'S1BS')
+    else:
+        print(f"Warning, odd structure for Vendor ID returned for {vendor_id}")
+
+    geotiff_dir = '/'.join(geotiff.split('\\')[:-1])
+    xmlfiles=  glob(geotiff_dir +'/*.XML')
+    xmlfile = [xmlfile for xmlfile in xmlfiles if '.aux.xml' not in xmlfile][0]
+    
+    cat_id = get_catid_from_xml(xmlfile)
+
+    pdf.loc[len(pdf)] = {
+        'catalog_id': cat_id,
+        'vendor_id': vendor_id
+    }
+
+# ----------------------------
+# Drop duplicates due to pan and multispectral
+# ----------------------------
+pdf = pdf.drop_duplicates(subset='vendor_id', keep='first')
+
+# ----------------------------
+# Add Catalog IDs to database
+# ----------------------------
+update_poi_from_dataframe(pdf, dry_run=False)

--- a/dba/update/troubleshoot.py
+++ b/dba/update/troubleshoot.py
@@ -1,0 +1,8 @@
+# ------------------------------------------------------------------------------
+#
+# Adds US Goverment Catalog IDs when provide with Vendor IDs as file names
+#   of GeoTIFFs.
+#
+# Written by John Wall (john.wall@noaa.gov)
+#
+# ------------------------------------------------------------------------------


### PR DESCRIPTION
- Add _add_interesting_points.py_, resolves some portion of [GAIFAGP-184](https://apps-st.fisheries.noaa.gov/jira/browse/GAIFAGP-184)
     - When provided with a user-defined directory containing GeoJSONs from Microsoft AI for Good's generate_interesting_points.py, load these into the SpatiaLite database for GAIA.
- Add _add_ids_from_files.py_, resolves [GAIFAGP-292](https://apps-st.fisheries.noaa.gov/jira/browse/GAIFAGP-292)
     - When provided with a directory of unzipped satellite imagery data, identify the Catalog ID and add it to the Catalog ID field within the SpataiLite database for  GAIA.
     - Allows for a dry run prior to committing records